### PR TITLE
Bug fixes for nerfstudio dataset

### DIFF
--- a/nerfbaselines/datasets/nerfstudio.py
+++ b/nerfbaselines/datasets/nerfstudio.py
@@ -397,14 +397,14 @@ def load_nerfstudio_dataset(path: Union[Path, str], split: str, downscale_factor
     c2w = poses[:, :3, :4]
 
     # Convert from OpenGL to OpenCV coordinate system
-    c2w[0:3, 1:3] *= -1
+    c2w[...,0:3, 1:3] *= -1
 
     all_cameras = new_cameras(
         poses=c2w.astype(np.float32),
         intrinsics=np.stack([fx, fy, cx, cy], -1).astype(np.float32),
         camera_models=np.full((len(poses),), camera_model_to_int(camera_type), dtype=np.uint8),
         distortion_parameters=distortion_params.astype(np.float32),
-        image_sizes=np.stack([height, width], -1).astype(np.int32),
+        image_sizes=np.stack([width, height], -1).astype(np.int32),
         nears_fars=None,
     )
 


### PR DESCRIPTION
Used a custom dataset of the nerfstudio type when running wild-gaussians and I found some bugs in how the dataset is loaded.

1. When converting the poses from OpenGL to OpenCV coordinate system, the fact that the poses are concatenated along dimension 0 was forgotten.
2. The image sizes where stored as [height, width] which was not in line with loading the images in dataset_load_features() in _common.py (there it is [width, height]). As a result, intrinsics where incorrectly rescaled in _dataset_rescale_intrinsics().