### PR TITLE
--logger argument supports user-defined loggers from registry.

### DIFF
--- a/nerfbaselines/cli/__init__.py
+++ b/nerfbaselines/cli/__init__.py
@@ -19,10 +19,9 @@ class LazyGroup(click.Group):
                 if ":" in package:
                     package, fname = package.split(":")
                 package = getattr(importlib.import_module(package, __name__), fname)
-            command = copy.deepcopy(package)
-            command.name = cmd_name
-            command.hidden = cmd_def.get("hidden", False)
-            return command
+            package.name = cmd_name
+            package.hidden = cmd_def.get("hidden", False)
+            return package
         return super().get_command(ctx, cmd_name)
 
     def list_commands(self, ctx):

--- a/nerfbaselines/cli/_train.py
+++ b/nerfbaselines/cli/_train.py
@@ -27,7 +27,7 @@ from ._common import SetParamOptionType, TupleClickType, IndicesClickType, click
 @click.option("--data", type=str, required=True, help=(
     "A path to the dataset to train on. The dataset can be either an external dataset (e.g., a path starting with `external://{dataset}/{scene}`) or a local path to a dataset. If the dataset is an external dataset, the dataset will be downloaded and cached locally. If the dataset is a local path, the dataset will be loaded directly from the specified path."))
 @click.option("--output", type=str, default=".", help="Output directory to save the training results", show_default=True)
-@click.option("--logger", type=click.Choice(["none", "wandb", "tensorboard", "wandb,tensorboard"]), default="tensorboard", help="Logger to use.", show_default=True)
+@click.option("--logger", type=str, default="tensorboard", help="Logger to use. Can also be list of loggers separated by commas (e.g., 'tensorboard,wandb')", show_default=True)
 @click.option("--save-iters", type=IndicesClickType(), default=Indices([-1]), help="When to save the model", show_default=True)
 @click.option("--eval-few-iters", type=IndicesClickType(), default=Indices.every_iters(2_000), help="When to evaluate on few images", show_default=True)
 @click.option("--eval-all-iters", type=IndicesClickType(), default=Indices([-1]), help="When to evaluate all images", show_default=True)


### PR DESCRIPTION
There is already support for user-defined loggers via the registry mechanism, but this argument prevents actually using them during training.